### PR TITLE
Fix aiohttp implementation of connection context close

### DIFF
--- a/graphql_ws/aiohttp.py
+++ b/graphql_ws/aiohttp.py
@@ -38,7 +38,7 @@ class AiohttpConnectionContext(BaseConnectionContext):
         return self.ws.closed
 
     async def close(self, code):
-        await self.ws.close(code)
+        await self.ws.close(code=code)
 
 
 class AiohttpSubscriptionServer(BaseSubscriptionServer):


### PR DESCRIPTION
This method does not accept any positional args; see [the `close()` method](http://aiohttp.readthedocs.io/en/stable/web_reference.html#aiohttp.web.WebSocketResponse.close) docs.