### PR TITLE
update graphiql cdn links

### DIFF
--- a/examples/flask_gevent/template.py
+++ b/examples/flask_gevent/template.py
@@ -18,11 +18,11 @@ def render_graphiql():
       width: 100%;
     }
   </style>
-  <link href="//cdn.jsdelivr.net/graphiql/${GRAPHIQL_VERSION}/graphiql.css" rel="stylesheet" />
+  <link href="//cdn.jsdelivr.net/npm/graphiql@${GRAPHIQL_VERSION}/graphiql.css" rel="stylesheet" />
   <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.0.0/react.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.0.0/react-dom.min.js"></script>
-  <script src="//cdn.jsdelivr.net/graphiql/${GRAPHIQL_VERSION}/graphiql.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/graphiql@${GRAPHIQL_VERSION}/graphiql.min.js"></script>
   <script src="//unpkg.com/subscriptions-transport-ws@${SUBSCRIPTIONS_TRANSPORT_VERSION}/browser/client.js"></script>
   <script src="//unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
 </head>

--- a/examples/flask_gevent/template.py
+++ b/examples/flask_gevent/template.py
@@ -117,7 +117,7 @@ def render_graphiql():
   </script>
 </body>
 </html>''').substitute(
-        GRAPHIQL_VERSION='0.11.7',
+        GRAPHIQL_VERSION='0.12.0',
         SUBSCRIPTIONS_TRANSPORT_VERSION='0.7.0',
         subscriptionsEndpoint='ws://localhost:5000/subscriptions',
         # subscriptionsEndpoint='ws://localhost:5000/',


### PR DESCRIPTION
# Issue
The following graphiql cdn links in the [flask_gevent](https://github.com/graphql-python/graphql-ws/tree/master/examples/flask_gevent) example are broken and return a 404.

* https://cdn.jsdelivr.net/graphiql/0.11.7/graphiql.css
 * https://cdn.jsdelivr.net/graphiql/0.11.7/graphiql.min.js

# Solution
Updated to working links.  It now uses the same ones used in  the [flask-graphql](https://github.com/graphql-python/flask-graphql/blob/master/flask_graphql/render_graphiql.py) template:

Resolves #3 