### PR TITLE
Fix dependency version range for graphql-core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "graphql-core>=2.0<3",
+    "graphql-core>=2.0,<3",
     # TODO: put package requirements here
 ]
 


### PR DESCRIPTION
Hi,

I think the version range expression used might work for Conda, but for PYPI/setuptools it gives the wrong version.

Found the issue while creating a new virtual environment for a project I am working at the moment.

```bash
Successfully built cylc-flow
ERROR: graphql-relay 2.0.0 has requirement graphql-core<3,>=2.2, but you'll have graphql-core 3.0.0 which is incompatible.
ERROR: graphene 2.1.8 has requirement graphql-core<3,>=2.1, but you'll have graphql-core 3.0.0 which is incompatible.
```

Tested installing `graphql-core` with `graphql-core<3,>=2.2` and it worked fine.

```bash
(venv) kinow@kinow-VirtualBox:/tmp$ pip install "graphql-core<3,>=2.2"
Collecting graphql-core<3,>=2.2
  Using cached https://files.pythonhosted.org/packages/6a/11/bc4a7eb440124271289d93e4d208bd07d94196038fabbe2a52435a07d3d3/graphql_core-2.2.1-py2.py3-none-any.whl
Processing /home/kinow/.cache/pip/wheels/92/84/9f/75e2235effae0e1c5a5c0626a503e532bbffcb7e79e672b606/promise-2.2.1-cp37-none-any.whl
Collecting rx<3,>=1.6
  Using cached https://files.pythonhosted.org/packages/33/0f/5ef4ac78e2a538cc1b054eb86285fe0bf7a5dbaeaac2c584757c300515e2/Rx-1.6.1-py2.py3-none-any.whl
Collecting six>=1.10.0
  Using cached https://files.pythonhosted.org/packages/65/26/32b8464df2a97e6dd1b656ed26b2c194606c16fe163c695a992b36c11cdf/six-1.13.0-py2.py3-none-any.whl
Installing collected packages: six, promise, rx, graphql-core
Successfully installed graphql-core-2.2.1 promise-2.2.1 rx-1.6.1 six-1.13.0
```

But if I use the syntax in `graphql-ws`'s `setup.py`, I get the 3.0.0 version instead.

```bash
(venv) kinow@kinow-VirtualBox:/tmp$ pip install "graphql-core>=2.0<3"
Collecting graphql-core>=2.0<3
  Using cached https://files.pythonhosted.org/packages/9d/88/7bd066ee74d36786c0aa4113d0022d47ff3423ad32c8e8346008cee03b85/graphql_core-3.0.0-py3-none-any.whl
Installing collected packages: graphql-core
Successfully installed graphql-core-3.0.0
```

This PR simply adds a comma between the two ranges. It fixes the issue when testing it locally.

```bash
(venv) kinow@kinow-VirtualBox:/tmp$ pip install "graphql-core>=2.0,<3"
Collecting graphql-core<3,>=2.0
  Using cached https://files.pythonhosted.org/packages/6a/11/bc4a7eb440124271289d93e4d208bd07d94196038fabbe2a52435a07d3d3/graphql_core-2.2.1-py2.py3-none-any.whl
Requirement already satisfied: rx<3,>=1.6 in ./venv/lib/python3.7/site-packages (from graphql-core<3,>=2.0) (1.6.1)
Requirement already satisfied: promise>=2.1 in ./venv/lib/python3.7/site-packages (from graphql-core<3,>=2.0) (2.2.1)
Requirement already satisfied: six>=1.10.0 in ./venv/lib/python3.7/site-packages (from graphql-core<3,>=2.0) (1.13.0)
Installing collected packages: graphql-core
Successfully installed graphql-core-2.2.1
```

Thanks
Bruno