### PR TITLE
add support for graphql-core 3 to graphql_ws.aiohttp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ deploy:
     python: 3.6
     repo: graphql-python/graphql-ws
     tags: true
-install: pip install -U tox-travis pytest-cov codecov
+install: pip install -U tox-travis codecov
 language: python
 python:
 - 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,14 @@ deploy:
       MnY1TzdSMDJ0d2xyS3pXWlB6SGxLWHVLc0dwemxCS3RLZ0RVQW02aEFBaFZwdDBVbUhTWnVtQ0I1
       cnFkWndJWFdTcEQ4SU8rRHMzTTdwbGMzMThPT2ZkOFo2MXU1dVlRZkFlUklURkRpNjVLUHp4Y1U9
   on:
-    python: 2.7
+    python: 3.6
     repo: graphql-python/graphql-ws
     tags: true
-install: pip install -U tox-travis
+install: pip install -U tox-travis pytest-cov codecov
 language: python
 python:
 - 3.8
 - 3.7
 - 3.6
-- 3.5
-- 2.7
-script: tox
+script: tox -- --cov-branch --cov-report=term-missing --cov=graphql_ws
+after_success: codecov

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Currently supports:
 * Sanic (uses [websockets](https://github.com/aaugustin/websockets/) library)
 
 [![PyPI version](https://badge.fury.io/py/graphql-ws.svg)](https://badge.fury.io/py/graphql-ws)
-[![TravisCI Build Status](https://github.com/graphql-python/graphql-ws.svg?branch=master)](https://github.com/graphql-python/graphql-ws)
-[![codecov](https://github.com/graphql-python/graphql-ws/branch/master/graph/badge.svg)](https://github.com/graphql-python/graphql-ws)
+[![TravisCI Build Status](https://travis-ci.org/graphql-python/graphql-ws.svg?branch=master)](https://travis-ci.org/graphql-python/graphql-ws)
+[![codecov](https://codecov.io/gh/graphql-python/graphql-ws/branch/master/graph/badge.svg)](https://codecov.io/gh/graphql-python/graphql-ws)
 
 # Installation instructions
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Currently supports:
 * [Gevent](https://github.com/graphql-python/graphql-ws#gevent)
 * Sanic (uses [websockets](https://github.com/aaugustin/websockets/) library)
 
+[![PyPI version](https://badge.fury.io/py/graphql-ws.svg)](https://badge.fury.io/py/graphql-ws)
+[![TravisCI Build Status](https://github.com/graphql-python/graphql-ws.svg?branch=master)](https://github.com/graphql-python/graphql-ws)
+[![codecov](https://github.com/graphql-python/graphql-ws/branch/master/graph/badge.svg)](https://github.com/graphql-python/graphql-ws)
+
 # Installation instructions
 
 For instaling graphql-ws, just run this command in your shell
@@ -167,8 +171,8 @@ class Subscription(graphene.ObjectType):
 
 
     def resolve_count_seconds(
-        root, 
-        info, 
+        root,
+        info,
         up_to=5
     ):
         return Observable.interval(1000)\

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ tox>=3,<4
 coverage>=5.0,<6
 Sphinx>=1.8,<2
 PyYAML>=5.3,<6
-pytest==3.2.5
+pytest<=3.6,<6
 pytest-runner>=5.2,<6
 gevent>=1.1,<2
 graphene>=2.0,<3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,3 +14,4 @@ django>=1.5,<3
 channels>=1.0,<2
 pytest-aiohttp
 asyncmock; python_version<"3.8"
+pytest-cov

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,3 +12,5 @@ gevent>=1.1,<2
 graphene>=2.0,<3
 django>=1.5,<3
 channels>=1.0,<2
+pytest-aiohttp
+asyncmock; python_version<"3.8"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 """The setup script."""
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open("README.rst") as readme_file:
     readme = readme_file.read()
@@ -14,7 +14,7 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "graphql-core>=2.0,<3",
+    "graphql-core>=3.0.0",
     # TODO: put package requirements here
 ]
 
@@ -26,7 +26,8 @@ setup_requirements = [
 
 test_requirements = [
     "pytest",
-    # TODO: put package test requirements here
+    "pytest-aiohttp",
+    'asyncmock; python_version<"3.8"',
 ]
 
 setup(
@@ -57,7 +58,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8"
+        "Programming Language :: Python :: 3.8",
     ],
     test_suite="tests",
     tests_require=test_requirements,

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -1,0 +1,135 @@
+import asyncio
+import sys
+from typing import Awaitable, Callable
+
+import pytest
+from aiohttp import WSMsgType
+from aiohttp.client import ClientWebSocketResponse
+from aiohttp.test_utils import TestClient
+from aiohttp.web import Application, WebSocketResponse
+from graphql import GraphQLSchema, build_schema
+from graphql_ws.aiohttp import AiohttpSubscriptionServer
+
+if sys.version_info >= (3, 8):
+    from unittest.mock import AsyncMock
+else:
+    from asyncmock import AsyncMock
+
+
+AiohttpClientFactory = Callable[[Application], Awaitable[TestClient]]
+
+
+def schema() -> GraphQLSchema:
+    spec = """
+    type Query {
+       dummy: String
+    }
+
+    type Subscription {
+      messages: String
+      error: String
+    }
+
+    schema {
+      query: Query
+      subscription: Subscription
+    }
+    """
+
+    async def messages_subscribe(root, _info):
+        await asyncio.sleep(0.1)
+        yield "foo"
+        await asyncio.sleep(0.1)
+        yield "bar"
+
+    async def error_subscribe(root, _info):
+        raise RuntimeError("baz")
+
+    schema = build_schema(spec)
+    schema.subscription_type.fields["messages"].subscribe = messages_subscribe
+    schema.subscription_type.fields["messages"].resolve = lambda evt, _info: evt
+    schema.subscription_type.fields["error"].subscribe = error_subscribe
+    schema.subscription_type.fields["error"].resolve = lambda evt, _info: evt
+    return schema
+
+
+@pytest.fixture
+def client(
+    loop: asyncio.AbstractEventLoop, aiohttp_client: AiohttpClientFactory
+) -> TestClient:
+    subscription_server = AiohttpSubscriptionServer(schema())
+
+    async def subscriptions(request):
+        conn = WebSocketResponse(protocols=('graphql-ws',))
+        await conn.prepare(request)
+        await subscription_server.handle(conn)
+        return conn
+
+    app = Application()
+    app["subscription_server"] = subscription_server
+    app.router.add_get('/subscriptions', subscriptions)
+    return loop.run_until_complete(aiohttp_client(app))
+
+
+@pytest.fixture
+async def connection(client: TestClient) -> ClientWebSocketResponse:
+    conn = await client.ws_connect("/subscriptions")
+    yield conn
+    await conn.close()
+
+
+async def test_connection_closed_on_error(connection: ClientWebSocketResponse):
+    connection._writer.transport.write(b'0' * 500)
+    response = await connection.receive()
+    assert response.type == WSMsgType.CLOSE
+
+
+async def test_connection_init(connection: ClientWebSocketResponse):
+    await connection.send_str('{"type":"connection_init","payload":{}}')
+    response = await connection.receive()
+    assert response.type == WSMsgType.TEXT
+    assert response.data == '{"type": "connection_ack"}'
+
+
+async def test_connection_init_rejected_on_error(
+    monkeypatch, client: TestClient, connection: ClientWebSocketResponse
+):
+    # raise exception in AiohttpSubscriptionServer.on_connect
+    monkeypatch.setattr(
+        client.app["subscription_server"],
+        "on_connect",
+        AsyncMock(side_effect=RuntimeError()),
+    )
+    await connection.send_str('{"type":"connection_init", "payload": {}}')
+    response = await connection.receive()
+    assert response.type == WSMsgType.TEXT
+    assert response.json()['type'] == 'connection_error'
+
+
+async def test_messages_subscription(connection: ClientWebSocketResponse):
+    await connection.send_str('{"type":"connection_init","payload":{}}')
+    await connection.receive()
+    await connection.send_str(
+        '{"id":"1","type":"start","payload":{"query":"subscription MySub { messages }"}}'
+    )
+    first = await connection.receive_str()
+    assert (
+        first == '{"id": "1", "type": "data", "payload": {"data": {"messages": "foo"}}}'
+    )
+    second = await connection.receive_str()
+    assert (
+        second
+        == '{"id": "1", "type": "data", "payload": {"data": {"messages": "bar"}}}'
+    )
+    resolve_message = await connection.receive_str()
+    assert resolve_message == '{"id": "1", "type": "complete"}'
+
+
+async def test_subscription_resolve_error(connection: ClientWebSocketResponse):
+    await connection.send_str('{"type":"connection_init","payload":{}}')
+    await connection.receive()
+    await connection.send_str(
+        '{"id":"2","type":"start","payload":{"query":"subscription MySub { error }"}}'
+    )
+    error = await connection.receive_json()
+    assert error["payload"]["errors"][0]["message"] == "baz"

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, flake8
+envlist = py36, py37, py38, flake8
 
 [travis]
 python =
     3.8: py38
     3.7: py37
     3.6: py36
-    3.5: py35
-    2.7: py27
 
 [testenv:flake8]
 basepython=python
@@ -22,11 +20,6 @@ deps =
 commands =
     pip install -U pip
     pytest --basetemp={envtmpdir}
-
-[testenv:py35]
-deps =
-    -r{toxinidir}/requirements_dev.txt
-    aiohttp>=3.6,<4
 
 [testenv:py36]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     -r{toxinidir}/requirements_dev.txt
 commands =
     pip install -U pip
-    pytest --basetemp={envtmpdir}
+    pytest --basetemp={envtmpdir} {posargs}
 
 [testenv:py36]
 deps =


### PR DESCRIPTION
Signed-off-by: oleg.hoefling <oleg.hoefling@gmail.com>

This PR adds support for `graphql-core>=3` to `graphql.aiohttp.AiohttpSubscriptionServer`. Note that this will break the rest of the `BaseSubscriptionServer` implementations! Unfortunately, I am not familiar with Sanic or `gevent` to adapt those too.

This PR violates against the PR submission rule
> 3 The pull request should work for Python 2.6, 2.7, 3.3, 3.4 and 3.5, and for PyPy. Check https://travis-ci.org/graphql-python/graphql_ws/pull_requests and make sure that the tests pass for all supported Python versions.

as `graphql-core>=3` is compatible with Python 3.6 onwards. Also, all of the Python versions listed have reached EOL anyway (except Python 3.5 which will reach EOL in September).