### PR TITLE
Register operation with connection context for gevent subscription

### DIFF
--- a/graphql_ws/gevent.py
+++ b/graphql_ws/gevent.py
@@ -73,13 +73,14 @@ class GeventSubscriptionServer(BaseSubscriptionServer):
                 connection_context.request_context, params)
             assert isinstance(execution_result, Observable), \
                 "A subscription must return an observable"
-            execution_result.subscribe(SubscriptionObserver(
+            disposable = execution_result.subscribe(SubscriptionObserver(
                 connection_context,
                 op_id,
                 self.send_execution_result,
                 self.send_error,
                 self.on_close
             ))
+            connection_context.register_operation(op_id, disposable)
         except Exception as e:
             self.send_error(connection_context, op_id, str(e))
 


### PR DESCRIPTION
Note: this fix comes from this old pull request https://github.com/graphql-python/graphql-ws/pull/11, I'm extracting it into its own PR since it is helpful independent of the pubsub implementation.

For verifying this bug, I loaded an app with a subscription, then reloaded the page multiple times. When an update happens, my backend logs that multiple updates were pushed out. With the proposed fix, only one update is sent out. Also, I noted that the other subscription server implementations (aiohttp/websockets_lib) have a `register_operation` call in their `on_start` handlers, but the gevent one does not.