### PR TITLE
:bug: Update to use latest channels spec

### DIFF
--- a/graphql_ws/django/routing.py
+++ b/graphql_ws/django/routing.py
@@ -10,7 +10,7 @@ else:
     AuthMiddlewareStack = None
 
 
-websocket_urlpatterns = [path("subscriptions", GraphQLSubscriptionConsumer)]
+websocket_urlpatterns = [path("subscriptions", GraphQLSubscriptionConsumer.as_asgi())]
 
 application = ProtocolTypeRouter({"websocket": URLRouter(websocket_urlpatterns)})
 


### PR DESCRIPTION
Hi there, this PR is in response to #68. I was using the latest Django channels version which needs a call to `as_asgi()` for consumers.